### PR TITLE
Add manifest and SMAPI build output configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ obj/
 
 **/bin/
 **/obj/
+
+# Mod output
+Mods/

--- a/src/AutoStardew/AutoStardew.csproj
+++ b/src/AutoStardew/AutoStardew.csproj
@@ -1,9 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <OutputPath>../../Mods/AutoStardew/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Update="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/AutoStardew/manifest.json
+++ b/src/AutoStardew/manifest.json
@@ -1,0 +1,8 @@
+{
+  "Name": "AutoStardew",
+  "Author": "your-name",
+  "Version": "0.1.0",
+  "Description": "AI-driven automation MVP",
+  "UniqueID": "yourname.AutoStardew",
+  "EntryDll": "AutoStardew.dll"
+}


### PR DESCRIPTION
## Summary
- add SMAPI `manifest.json` for AutoStardew mod
- configure project to output compiled mod to `Mods/AutoStardew` and copy manifest
- ignore packaged mod directory in git

## Testing
- `dotnet build src/AutoStardew -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68b076d4389083209fc452d1e4ffca87